### PR TITLE
Fix: Handle connection to vbar control service correctly

### DIFF
--- a/cmd/tpu-dra-kubeletplugin/util.go
+++ b/cmd/tpu-dra-kubeletplugin/util.go
@@ -40,6 +40,7 @@ const (
 	ICIResiliencyEnv             = "ENABLE_ICI_RESILIENCY"
 	ProvisionOnlyTopologyMode    = "PROVISION_ONLY"
 	RootDirectory                = "/"
+	NodeIPEnv                    = "NODE_IP"
 )
 
 var (
@@ -190,7 +191,12 @@ func InitEnvs(opts InitEnvOptions) (map[string]string, error) {
 		envs["TPU_ACCELERATOR_TYPE"] = acceleratorTypeConverted
 	}
 
-	envs["VBAR_CONTROL_SERVICE_URL"] = "unix:///var/run/tpu-plugin/vbar.sock"
+	nodeIp, err := GetEnvName(NodeIPEnv)
+	if err != nil {
+		klog.Infof("$NODE_IP is not set in env")
+	} else {
+		envs["VBAR_CONTROL_SERVICE_URL"] = nodeIp + ":8353"
+	}
 
 	if opts.EnableDeviceSpreading && opts.IsPriviledged && len(opts.VisibleChipIds) > 0 {
 		envs["TPU_VISIBLE_CHIPS"] = strings.Join(opts.VisibleChipIds, ",")
@@ -213,6 +219,14 @@ func InitEnvs(opts InitEnvOptions) (map[string]string, error) {
 		addSingleHostEnvs(envs)
 	}
 	return envs, nil
+}
+
+func GetEnvName(envName string) (string, error) {
+	env := os.Getenv(envName)
+	if len(env) == 0 {
+		return "", fmt.Errorf("empty %s environment variable", envName)
+	}
+	return env, nil
 }
 
 func ChipCount(chipCount string) (int, error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The driver needs to be able to connect to the vbar control service for the v6 generation of TPUs. This fixes incorrect handling of that connection.


#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fix TPUv6 support with correct vbar control service endpoint.
```
