### PR TITLE
Make the tpu-test Pod usable for checking real TPUs

### DIFF
--- a/demo/specs/tpu-test.yaml
+++ b/demo/specs/tpu-test.yaml
@@ -31,6 +31,10 @@ metadata:
   labels:
     app: pod
 spec:
+  tolerations:
+  - key: "google.com/tpu"
+    operator: "Exists"
+    effect: "NoSchedule"
   containers:
   - name: ctr0
     image: busybox:latest
@@ -40,8 +44,10 @@ spec:
         - |
           echo "Environment Variables:"
           env
-          echo "Listing mounts"
+          echo "Listing v4 mounts"
           ls /dev/ | grep 'accel'
+          echo "Listing v5+ mounts"
+          ls /dev/vfio
           echo "Listing log mounts:"
           ls /tmp
           echo "Sleeping indefinitely..."


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This fixes the put-test Pod so it works on real TPU nodes on GKE. It also updates it to print the mounts for v5+ generations of TPUs.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
