### PR TITLE
Fix registry used in helm chart 

### DIFF
--- a/demo/scripts/common.sh
+++ b/demo/scripts/common.sh
@@ -25,7 +25,7 @@ SCRIPTS_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
 : ${DRIVER_NAME:=dra-driver-google-tpu}
 
 # The registry, image and tag for the Google TPU DRA driver
-: ${REGISTRY:="registry.k8s.io/dra-driver-google-tpu"}
+: ${REGISTRY:="registry.k8s.io/dra-driver-google"}
 : ${IMAGE:="${DRIVER_NAME}"}
 : ${TAG:="v$(cat $(git rev-parse --show-toplevel)/deployments/helm/${DRIVER_NAME}/Chart.yaml | grep appVersion | sed 's/"//g' | sed -n 's/^appVersion: //p')"}
 

--- a/deployments/helm/dra-driver-google-tpu/values.yaml
+++ b/deployments/helm/dra-driver-google-tpu/values.yaml
@@ -13,7 +13,7 @@ deviceClasses: ["tpu"]
 
 imagePullSecrets: []
 image:
-  repository: registry.k8s.io/dra-driver-google-tpu
+  repository: registry.k8s.io/dra-driver-google/dra-driver-google-tpu
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We turns out to use `registry.k8s.io/dra-driver-google` as the registry because of naming limitation in kubernetes groups. Ref: https://github.com/kubernetes/k8s.io/pull/9400
#### Which issue(s) this PR is related to:
N/A
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:

Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the string
"action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
